### PR TITLE
add a patch to enable shell completions

### DIFF
--- a/.patches/homebrew-add-completions.patch
+++ b/.patches/homebrew-add-completions.patch
@@ -1,0 +1,8 @@
+--- Formula/svix-cli-orig.rb	2025-10-10 09:47:21
++++ Formula/svix-cli.rb	2025-10-10 09:47:42
+@@ -65,4 +65,5 @@
+
+     install_binary_aliases!
++    generate_completions_from_executable(bin/"svix", "completion", shells: %i[bash fish zsh])
+
+     # Homebrew will automatically install these, so we don't need to do that

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+This repository contains a [Homebrew](https://brew.sh/) tap for installing the [Svix](https://www.svix.com) command-line interface, `svix-cli`.
+
+It is updated exclusively through `cargo-dist` release automation in [svix-webhooks](https://github.com/svix/svix-webhooks).


### PR DESCRIPTION
This is tricky! The formula is recreated by `cargo-dist` on every release, so we can't just edit it, and `cargo-dist` doesn't let you customize the formula it generates at all.

What I've settled on is checking in a regular old `.patch` file, and then I will modify the release action to apply it.

Part of #1 